### PR TITLE
修复在处理多级目录结构时， hide: true 没有被移除的 bug

### DIFF
--- a/feishu-pages/src/index.ts
+++ b/feishu-pages/src/index.ts
@@ -13,7 +13,7 @@ import {
   fetchTenantAccessToken,
 } from './feishu';
 import { FileDoc, generateSummary, prepareDocSlugs } from './summary';
-import { humanizeFileSize } from './utils';
+import { humanizeFileSize, cleanupDocsForJSON } from './utils';
 import { fetchAllDocs } from './wiki';
 
 // App entry
@@ -52,38 +52,6 @@ import { fetchAllDocs } from './wiki';
   );
 })();
 
-const allowKeys = [
-  'depth',
-  'title',
-  'slug',
-  'filename',
-  'node_token',
-  'parent_node_token',
-  'children',
-  'obj_create_time',
-  'obj_edit_time',
-  'obj_token',
-  'has_child',
-  'meta',
-  'position',
-];
-const cleanupDocsForJSON = (docs: FileDoc[]) => {
-  for (let idx = 0; idx < docs.length; idx++) {
-    const doc = docs[idx];
-
-    Object.keys(doc).forEach((key) => {
-      if (!allowKeys.includes(key)) {
-        delete doc[key];
-      }
-    });
-
-    if (doc.meta?.hide) {
-      docs.splice(idx, 1);
-    }
-
-    cleanupDocsForJSON(doc.children);
-  }
-};
 
 const fetchDocBodies = async (docs: FileDoc[]) => {
   for (let idx = 0; idx < docs.length; idx++) {

--- a/feishu-pages/src/utils.ts
+++ b/feishu-pages/src/utils.ts
@@ -1,3 +1,5 @@
+import { FileDoc } from "./summary";
+
 export const normalizeSlug = (slug: string | number) => {
   // force convert slug into string
   slug = String(slug);
@@ -33,3 +35,46 @@ export const humanizeFileSize = (bytes, dp = 1) => {
 
   return bytes.toFixed(dp) + ' ' + units[u];
 };
+
+const allowKeys = [
+  "depth",
+  "title",
+  "slug",
+  "filename",
+  "node_token",
+  "parent_node_token",
+  "children",
+  "obj_create_time",
+  "obj_edit_time",
+  "obj_token",
+  "has_child",
+  "meta",
+  "position"
+];
+
+export function cleanupDocsForJSON(docs: FileDoc[]) {
+  const nodesToDelete = [];
+
+  for (let idx = 0; idx < docs.length; idx++) {
+    const doc = docs[idx];
+
+    Object.keys(doc).forEach(key => {
+      if (!allowKeys.includes(key)) {
+        delete doc[key];
+      }
+    });
+
+    if (doc.meta?.hide) {
+      nodesToDelete.push(idx);
+    }
+
+    if (doc.children) {
+      cleanupDocsForJSON(doc.children);
+    }
+  }
+
+  // Delete nodes in reverse order to avoid index issues
+  for (let i = nodesToDelete.length - 1; i >= 0; i--) {
+    docs.splice(nodesToDelete[i], 1);
+  }
+}

--- a/feishu-pages/tests/utils.test.ts
+++ b/feishu-pages/tests/utils.test.ts
@@ -1,17 +1,100 @@
-import { describe, test } from '@jest/globals';
-import assert from 'node:assert';
-import { humanizeFileSize, normalizeSlug } from '../src/utils';
+import { describe, test, expect } from "@jest/globals";
+import assert from "node:assert";
+import {
+  humanizeFileSize,
+  normalizeSlug,
+  cleanupDocsForJSON
+} from "../src/utils";
 
-describe('Utils', () => {
-  test('normalizeSlug', () => {
-    assert.equal(normalizeSlug('foo-bar'), 'foo-bar');
-    assert.equal(normalizeSlug('wikcnfoo-bar'), 'foo-bar');
-    assert.equal(normalizeSlug('wikenfoo-bar'), 'foo-bar');
+describe("Utils", () => {
+  test("normalizeSlug", () => {
+    assert.equal(normalizeSlug("foo-bar"), "foo-bar");
+    assert.equal(normalizeSlug("wikcnfoo-bar"), "foo-bar");
+    assert.equal(normalizeSlug("wikenfoo-bar"), "foo-bar");
   });
 
-  test('humanizeFileSize', () => {
-    assert.equal(humanizeFileSize(1209482), '1.2 MB');
-    assert.equal(humanizeFileSize(810473), '791.5 kB');
-    assert.equal(humanizeFileSize(4621), '4.5 kB');
+  test("humanizeFileSize", () => {
+    assert.equal(humanizeFileSize(1209482), "1.2 MB");
+    assert.equal(humanizeFileSize(810473), "791.5 kB");
+    assert.equal(humanizeFileSize(4621), "4.5 kB");
+  });
+
+  test("cleanupDocsForJSON", () => {
+    const rawDocs: any = [
+      {
+        title: "title1",
+        meta: {
+          slug: "app1"
+        },
+        children: [
+          {
+            title: "title1-1",
+            meta: {
+              slug: "app1-1",
+              hide: true
+            }
+          },
+          {
+            title: "title1-2",
+            meta: {
+              slug: "app1-2"
+            },
+            children: [
+              {
+                title: "title1-2-1",
+                meta: {
+                  slug: "app1-2-1"
+                }
+              },
+              {
+                title: "title1-2-2",
+                meta: {
+                  slug: "app1-2-2",
+                  hide: true
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        title: "title2",
+        meta: {
+          slug: "app2",
+          hide: true
+        },
+        children: [
+          {
+            title: "title2-1",
+            meta: {
+              slug: "app2-1"
+            }
+          },
+          {
+            title: "title2-2",
+            meta: {
+              slug: "app2-2"
+            }
+          }
+        ]
+      }
+    ];
+    cleanupDocsForJSON(rawDocs);
+
+    expect(rawDocs).toStrictEqual([
+      {
+        children: [
+          {
+            children: [
+              { meta: { slug: "app1-2-1" }, title: "title1-2-1" },
+            ],
+            meta: { slug: "app1-2" },
+            title: "title1-2"
+          }
+        ],
+        meta: { slug: "app1" },
+        title: "title1"
+      }
+    ]);
   });
 });


### PR DESCRIPTION
Fix the bug where nested 'children' were not being removed when removing nodes with 'meta' set to 'hide' in 'docs'.