### PR TITLE
Revert: Improved cache use to avoid download images if the content was not changed.

### DIFF
--- a/feishu-pages/package.json
+++ b/feishu-pages/package.json
@@ -1,6 +1,6 @@
 {
   "name": "feishu-pages",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "description": "Generate Feishu Wiki into a Markdown for work with Static Page Generators.",
   "repository": {
     "url": "https://github.com/longbridgeapp/feishu-pages"

--- a/feishu-pages/package.json
+++ b/feishu-pages/package.json
@@ -1,6 +1,6 @@
 {
   "name": "feishu-pages",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "description": "Generate Feishu Wiki into a Markdown for work with Static Page Generators.",
   "repository": {
     "url": "https://github.com/longbridgeapp/feishu-pages"

--- a/feishu-pages/src/feishu.ts
+++ b/feishu-pages/src/feishu.ts
@@ -242,7 +242,12 @@ const isValidCacheExist = (cacheFilePath: string) => {
  * @param localPath
  * @returns
  */
-export const feishuDownload = async (fileToken: string, localPath: string, type: 'file' | 'image' | 'board') => {
+export const feishuDownload = async (
+  fileToken: string,
+  localPath: string,
+  type: 'file' | 'image' | 'board',
+  hasDocCache: boolean,
+) => {
   const cacheFilePath = path.join(CACHE_DIR, fileToken);
   const cacheFileMetaPath = path.join(CACHE_DIR, `${fileToken}.headers.json`);
   fs.mkdirSync(CACHE_DIR, { recursive: true });
@@ -250,7 +255,7 @@ export const feishuDownload = async (fileToken: string, localPath: string, type:
   let res: { data?: fs.ReadStream; headers?: Record<string, any> } = {};
   let hasCache = false;
   // The board file can't be cached, because we can't get the content-length
-  let canCache = type != 'board';
+  let canCache = type != 'board' || hasDocCache;
 
   let cacheFileHeaders = {};
   try {

--- a/feishu-pages/src/index.ts
+++ b/feishu-pages/src/index.ts
@@ -119,9 +119,7 @@ const fetchDocAndWriteFile = async (
     let out = '';
     out += metaInfo + '\n\n';
 
-    if (!doc.hasCache) {
-      content = await downloadFiles(content, fileTokens, folder);
-    }
+    content = await downloadFiles(content, fileTokens, doc.hasCache);
 
     out += content;
 
@@ -149,7 +147,7 @@ const fetchDocAndWriteFile = async (
 const downloadFiles = async (
   content: string,
   fileTokens: Record<string, FileToken>,
-  docFolder: string
+  hasDocCache: boolean,
 ) => {
   if (SKIP_ASSETS) {
     console.info('skip assets download.');
@@ -165,7 +163,8 @@ const downloadFiles = async (
     const filePath = await feishuDownload(
       fileToken,
       path.join(path.join(DOCS_DIR, 'assets'), base_filename),
-      fileTokens[fileToken].type
+      fileTokens[fileToken].type,
+      hasDocCache,
     );
     if (!filePath) {
       continue;


### PR DESCRIPTION
目前新的画板图片下载触发逻辑：只有当文档内容有变化，并且没缓存的情况下，画板的图片会触发下载更新。因此如果仅更新画板是不会更新内容的，需要确保主文档也修改一下，确保文档页面会更新。